### PR TITLE
Update master_types in defaults.yaml

### DIFF
--- a/salt/defaults.yaml
+++ b/salt/defaults.yaml
@@ -58,7 +58,7 @@ salt:
   master:
     gitfs_provider: gitpython
   minion:
-    master_type: true  # see init.sls & standalone.sls
+    master_type: str  # see init.sls & standalone.sls
 
   gitfs:
     dulwich:


### PR DESCRIPTION
Set salt:minion:master_type to 'str' in defautls.yaml as that is in the default value for the salt-minion config. Setting master_type to true causes an error with the minion config when the salt-minion starts